### PR TITLE
fix: LoginWindow notitlebar no work

### DIFF
--- a/src/ui/login_window.cpp
+++ b/src/ui/login_window.cpp
@@ -25,6 +25,7 @@
 #include <DGuiApplicationHelper>
 #include <DTitlebar>
 #include <DWidgetUtil>
+#include <DPlatformWindowHandle>
 #include <QNetworkReply>
 #include <string>
 #include "sync_client.h"
@@ -589,4 +590,13 @@ void LoginWindow::closeEvent(QCloseEvent *event)
     QWidget::closeEvent(event);
 }
 
+bool LoginWindow::event(QEvent *event)
+{
+    // FIX #8853 notitlebar not work
+    // QWebEngineView in Qt6 will recreate window handle...
+    if (QEvent::WinIdChange == event->type())
+        Dtk::Widget::DPlatformWindowHandle handle(this);
+
+    return Dtk::Widget::DMainWindow::event(event);
+}
 }

--- a/src/ui/login_window.h
+++ b/src/ui/login_window.h
@@ -81,6 +81,7 @@ protected Q_SLOTS:
 
 protected:
     void closeEvent(QCloseEvent*) Q_DECL_OVERRIDE;
+    bool event(QEvent *event) Q_DECL_OVERRIDE;
 
     bool windowloadingEnd = true;
     bool pageLoadOK = true;


### PR DESCRIPTION
Qt6 的 webengineview 会重新创建窗口
导致之前设置的属性无效，需要重新设置一次

Issue: https://github.com/linuxdeepin/developer-center/issues/8853