### PR TITLE
fix: blank deepinid login dialog and exit abnormally when offline

### DIFF
--- a/src/ui/login_window.cpp
+++ b/src/ui/login_window.cpp
@@ -387,8 +387,13 @@ LoginWindow::LoginWindow(QWidget *parent)
             QNetworkConfigurationManager mgr;
             if(!mgr.isOnline()) {
             #else
-            QNetworkInformation *netInfo = QNetworkInformation::instance();
-            if(netInfo->reachability() != QNetworkInformation::Reachability::Online) {
+            bool reachable = false;
+            if (QNetworkInformation::loadDefaultBackend()) {
+                qDebug() << "load network information default backend succeeded";
+                QNetworkInformation *netInfo = QNetworkInformation::instance();
+                reachable = netInfo->reachability() == QNetworkInformation::Reachability::Online;
+            }
+            if(!reachable) {
             #endif
                 d->page->load(QUrl(
                                   QString("qrc:/web/network_error.html?%1").


### PR DESCRIPTION
Need to call QNetworkInformation::load() before
QNetworkInformation::instance()

Bug: https://pms.uniontech.com/bug-view-271685.html
Log: blank deepinid login dialog and exit abnormally when offline