### PR TITLE
feat: add depends libqt6webenginecore6-bin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-deepinid-client (7.0.9) unstable; urgency=medium
+
+  * add depends libqt6webenginecore6-bin.
+
+ -- lichenggang <lichenggang@deepin.org>  Thu, 21 Nov 2024 20:42:07 +0800
+
 deepin-deepinid-client (7.0.8) unstable; urgency=medium
 
   * fix: do not pop up the login window when the network fluctuates

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,6 @@ Homepage: https://www.deepin.org
 
 Package: deepin-deepinid-client
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libdframeworkdbus2, dcc-deepinid-plugin
+Depends: ${shlibs:Depends}, ${misc:Depends}, libdframeworkdbus2, dcc-deepinid-plugin, libqt6webenginecore6-bin
 Description: client to login deepin sync account
  Deepin user can login with DeepinID oauth


### PR DESCRIPTION
  add depends libqt6webenginecore6-bin

Log:  在Qt6下面需要添加libqt6webenginecore6-bin 运行时依赖库